### PR TITLE
Update to MP6.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 50

--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -1,0 +1,18 @@
+name: Add PRs to Dependabot PRs dashboard
+
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add PR to dashboard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/OpenLiberty/projects/26
+          github-token: ${{ secrets.ADMIN_BACKLOG }}
+          labeled: dependencies

--- a/finish/inventory/pom.xml
+++ b/finish/inventory/pom.xml
@@ -31,8 +31,8 @@
         <!-- end::inventory-node-port[] -->
         <!-- Liberty configuration -->
         <liberty.var.system.http.port>9080</liberty.var.system.http.port>
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9080</liberty.var.http.port>
+        <liberty.var.https.port>9443</liberty.var.https.port>
     </properties>
 
     <!-- Provided dependencies -->
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -54,19 +54,19 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-binding-provider</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -89,19 +89,19 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
                         <cluster.ip>${cluster.ip}</cluster.ip>

--- a/finish/inventory/src/main/liberty/config/server.xml
+++ b/finish/inventory/src/main/liberty/config/server.xml
@@ -5,15 +5,15 @@
     <feature>jsonb-3.0</feature>
     <feature>cdi-4.0</feature>
     <feature>mpRestClient-3.0</feature>
-    <feature>mpConfig-3.0</feature>
+    <feature>mpConfig-3.1</feature>
     <feature>jsonp-2.1</feature>
   </featureManager>
 
   <variable name="system.http.port" defaultValue="9080"/>
-  <variable name="default.http.port" defaultValue="9080"/>
-  <variable name="default.https.port" defaultValue="9443"/>
+  <variable name="http.port" defaultValue="9080"/>
+  <variable name="https.port" defaultValue="9443"/>
 
-  <httpEndpoint host="*" httpPort="${default.http.port}" httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
+  <httpEndpoint host="*" httpPort="${http.port}" httpsPort="${https.port}" id="defaultHttpEndpoint"/>
 
   <webApplication location="guide-cloud-aws-inventory.war" contextRoot="/"/>
 </server>

--- a/finish/inventory/src/main/webapp/index.html
+++ b/finish/inventory/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2023 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 ​
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -30,11 +30,11 @@
     <p>
         For more information about the features used in this application, see the Open Liberty documentation:
         <ul>
-            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.0</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html" target="_blank" rel="noopener noreferrer">Jakarta RESTful Web Services 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html" target="_blank" rel="noopener noreferrer">Jakarta Contexts and Dependency Injection 4.0</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#mpRestClient-3.0.html" target="_blank" rel="noopener noreferrer">MicroProfile Rest Client 3.0</a></li>
-            <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.0.html" target="_blank" rel="noopener noreferrer">MicroProfile Config 3.0</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.1.html" target="_blank" rel="noopener noreferrer">MicroProfile Config 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Processing 2.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#jsonb-3.0.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Binding 3.0</a></li>
         </ul>

--- a/finish/system/pom.xml
+++ b/finish/system/pom.xml
@@ -20,8 +20,8 @@
         <cluster.ip>localhost</cluster.ip>
         <system.node.port>31000</system.node.port>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9080</liberty.var.http.port>
+        <liberty.var.https.port>9443</liberty.var.https.port>
     </properties>
 
     <!-- Provided dependancies -->
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -43,19 +43,19 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-binding-provider</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -72,19 +72,19 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
                         <cluster.ip>${cluster.ip}</cluster.ip>

--- a/finish/system/src/main/liberty/config/server.xml
+++ b/finish/system/src/main/liberty/config/server.xml
@@ -7,10 +7,10 @@
     <feature>jsonp-2.1</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="9080"/>
-  <variable name="default.https.port" defaultValue="9443"/>
+  <variable name="http.port" defaultValue="9080"/>
+  <variable name="https.port" defaultValue="9443"/>
   
-  <httpEndpoint host="*" httpPort="${default.http.port}" httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
+  <httpEndpoint host="*" httpPort="${http.port}" httpsPort="${https.port}" id="defaultHttpEndpoint"/>
 
   <webApplication location="guide-cloud-aws-system.war" contextRoot="/"/>
 </server>

--- a/finish/system/src/main/webapp/index.html
+++ b/finish/system/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2023 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 ​
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@
     <p>
         For more information about the features used in this application, see the Open Liberty documentation:
         <ul>
-            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.0</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html" target="_blank" rel="noopener noreferrer">Jakarta RESTful Web Services 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html" target="_blank" rel="noopener noreferrer">Jakarta Contexts and Dependency Injection 4.0</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Processing 2.1</a></li>

--- a/start/inventory/pom.xml
+++ b/start/inventory/pom.xml
@@ -23,8 +23,8 @@
         <inventory.node.port>32000</inventory.node.port>
         <!-- Liberty configuration -->
         <liberty.var.system.http.port>9080</liberty.var.system.http.port>
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9080</liberty.var.http.port>
+        <liberty.var.https.port>9443</liberty.var.https.port>
     </properties>
 
     <!-- Provided dependencies -->
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -46,19 +46,19 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-binding-provider</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -81,19 +81,19 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
                         <cluster.ip>${cluster.ip}</cluster.ip>

--- a/start/inventory/src/main/liberty/config/server.xml
+++ b/start/inventory/src/main/liberty/config/server.xml
@@ -5,15 +5,15 @@
     <feature>jsonb-3.0</feature>
     <feature>cdi-4.0</feature>
     <feature>mpRestClient-3.0</feature>
-    <feature>mpConfig-3.0</feature>
+    <feature>mpConfig-3.1</feature>
     <feature>jsonp-2.1</feature>
   </featureManager>
 
   <variable name="system.http.port" defaultValue="9080"/>
-  <variable name="default.http.port" defaultValue="9080"/>
-  <variable name="default.https.port" defaultValue="9443"/>
+  <variable name="http.port" defaultValue="9080"/>
+  <variable name="https.port" defaultValue="9443"/>
 
-  <httpEndpoint host="*" httpPort="${default.http.port}" httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
+  <httpEndpoint host="*" httpPort="${http.port}" httpsPort="${https.port}" id="defaultHttpEndpoint"/>
 
   <webApplication location="guide-cloud-aws-inventory.war" contextRoot="/"/>
 </server>

--- a/start/inventory/src/main/webapp/index.html
+++ b/start/inventory/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2023 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 ​
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -30,11 +30,11 @@
     <p>
         For more information about the features used in this application, see the Open Liberty documentation:
         <ul>
-            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.0</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html" target="_blank" rel="noopener noreferrer">Jakarta RESTful Web Services 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html" target="_blank" rel="noopener noreferrer">Jakarta Contexts and Dependency Injection 4.0</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#mpRestClient-3.0.html" target="_blank" rel="noopener noreferrer">MicroProfile Rest Client 3.0</a></li>
-            <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.0.html" target="_blank" rel="noopener noreferrer">MicroProfile Config 3.0</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.1.html" target="_blank" rel="noopener noreferrer">MicroProfile Config 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Processing 2.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#jsonb-3.0.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Binding 3.0</a></li>
         </ul>

--- a/start/system/pom.xml
+++ b/start/system/pom.xml
@@ -20,8 +20,8 @@
         <cluster.ip>localhost</cluster.ip>
         <system.node.port>31000</system.node.port>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9080</liberty.var.http.port>
+        <liberty.var.https.port>9443</liberty.var.https.port>
     </properties>
 
     <!-- Provided dependancies -->
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -43,19 +43,19 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-binding-provider</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -72,19 +72,19 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
                         <cluster.ip>${cluster.ip}</cluster.ip>

--- a/start/system/src/main/liberty/config/server.xml
+++ b/start/system/src/main/liberty/config/server.xml
@@ -7,10 +7,10 @@
     <feature>jsonp-2.1</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="9080"/>
-  <variable name="default.https.port" defaultValue="9443"/>
+  <variable name="http.port" defaultValue="9080"/>
+  <variable name="https.port" defaultValue="9443"/>
   
-  <httpEndpoint host="*" httpPort="${default.http.port}" httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
+  <httpEndpoint host="*" httpPort="${http.port}" httpsPort="${https.port}" id="defaultHttpEndpoint"/>
 
   <webApplication location="guide-cloud-aws-system.war" contextRoot="/"/>
 </server>

--- a/start/system/src/main/webapp/index.html
+++ b/start/system/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2023 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 ​
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@
     <p>
         For more information about the features used in this application, see the Open Liberty documentation:
         <ul>
-            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.0</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html" target="_blank" rel="noopener noreferrer">Jakarta RESTful Web Services 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html" target="_blank" rel="noopener noreferrer">Jakarta Contexts and Dependency Injection 4.0</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Processing 2.1</a></li>


### PR DESCRIPTION
address issue: https://github.com/OpenLiberty/guides-common/issues/1021

### Review changes
- [x] pom.xml
  - microfile-profile is 6.1, and dependencies
  - LMP 3.10
  - `default.` should be removed
  - ports `9090`,`9453`,`9091`,`9454` if guide uses local kube
- [x] server.xml
  - feature version
- [x] index.html
  - feature version
- [x] update lgdev with `version-update-mp61` branch
- [x] do end-to-end test and review content carefully
  - clone the `version-update-mp61` branch
  - if index.html has changes, make sure the links work

